### PR TITLE
Fixed outputTimeTable and outputTimeTableTotals markup

### DIFF
--- a/src/assets/js/statsioparser.js
+++ b/src/assets/js/statsioparser.js
@@ -353,7 +353,7 @@ function outputTimeTable(timeValues, langTitle, langDuration, elapsedLabel, cpuL
     //result += '<td class="td-column-right">' + numeral(timeValues.elapsed).format('0,0') + '</td>';
     result += '<td class="td-column-right">' + formatms(timeValues.cpu) + '</td>';
     result += '<td class="td-column-right">' + formatms(timeValues.elapsed) + '</td>';
-    result += '</tr></tbody></table><div>';
+    result += '</tr></tbody></table></div>';
 
     return result;
 }
@@ -390,7 +390,7 @@ function outputTimeTableTotals(executionValues, compileValues, langCompileTitle,
     //result += '<td class="td-total td-column-right">' + numeral(elapsedTotal).format('0,0') + '</td>';
     result += '<td class="td-total td-column-right">' + formatms(cpuTotal) + '</td>';
     result += '<td class="td-total td-column-right">' + formatms(elapsedTotal) + '</td>';
-    result += '</tr></tfoot></table><div>';
+    result += '</tr></tfoot></table></div>';
 
     return result;
 }


### PR DESCRIPTION
The `<div>` element is not closed correctly right now. This causes the browser to do a bit of error-correction. The error-correction process itself is a bit buggy, and in this case it creates a hierarchy of tables instead of putting tables side-by-side. That causes performance issues when large amount of data is loaded.

This change should fix: https://github.com/Jorriss/StatisticsParser/issues/34